### PR TITLE
Removed extra environment to make twitter work

### DIFF
--- a/spotters.yaml
+++ b/spotters.yaml
@@ -190,7 +190,6 @@ services:
       - SCWEET_USERNAME=${SCWEET_USERNAME}
       - SCWEET_PASSWORD=${SCWEET_PASSWORD}
       - SCWEET_COOKIE=${SCWEET_COOKIE}
-    environment:
       - TRACE=${TRACE:-false}
 
   youtube00e1f862e5eff:


### PR DESCRIPTION
In the Twitter spotter there was an extra environment flag that was stopping it from working removed it and now works.

